### PR TITLE
Enable the physical button and create backlight timeout logic

### DIFF
--- a/hypnos/include/event_handler.h
+++ b/hypnos/include/event_handler.h
@@ -10,8 +10,10 @@
 #include <drivers/gpio.h>
 
 void event_handler_init(void);
-void battery_percentage_interrupt_handler(struct k_timer*);
-void battery_callback_charging(struct device*, struct gpio_callback*, u32_t);
+void backlight_off_interrupt_handler(struct k_timer *);
+void battery_percentage_interrupt_handler(struct k_timer *);
+void battery_callback_charging(struct device*, struct gpio_callback *, u32_t);
 void clock_callback_tick(struct k_timer *);
+void button_callback(struct device *, struct gpio_callback *, u32_t);
 
 #endif /* EVENT_HANDLER */

--- a/hypnos/src/battery.c
+++ b/hypnos/src/battery.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020 Endian Technologies AB
  *
- * SPDX-License-Identifier: MPL-2.0 AND Apache-2.0
+ * SPDX-License-Identifier: MPL-2.0
  *
  * battery_mv_to_ppt, battery_level_point, battery_raw_to_mv:
  * Copyright (c) 2020 Nordic Semiconductor

--- a/hypnos/src/event_handler.c
+++ b/hypnos/src/event_handler.c
@@ -14,15 +14,23 @@
 
 /* ********** defines ********** */
 #define BAT_PERCENTAGE_READ_INTERVAL K_MINUTES(5)
-#define BAT_CHA_PIN 12
+#define BAT_CHA 12
+#define BTN_PORT DT_ALIAS_SW0_GPIOS_CONTROLLER
+#define BTN_IN  DT_ALIAS_SW0_GPIOS_PIN
+#define BTN_OUT 15
+#define EDGE    (GPIO_INT_EDGE | GPIO_INT_DOUBLE_EDGE)
+#define PULL_UP DT_ALIAS_SW0_GPIOS_FLAGS
+#define BACKLIGHT_OFF_TIME K_SECONDS(5)
 /* ********** defines ********** */
-
 
 /* ********** variables ********** */
 static struct k_timer battery_percentage_timer;
 static struct k_timer clock_tick_timer;
+static struct k_timer backlight_off_timer;
 static struct device *charging_dev;
 static struct gpio_callback charging_cb;
+static struct device *button_dev;
+static struct gpio_callback button_cb;
 /* ********** variables ********** */
 
 /* ********** init function ********** */
@@ -32,16 +40,28 @@ void event_handler_init()
 
 	/* Initialize GPIOs */
         charging_dev = device_get_binding("GPIO_0");
-        gpio_pin_configure(charging_dev, BAT_CHA_PIN, GPIO_DIR_IN | GPIO_INT
-                | GPIO_INT_EDGE | GPIO_INT_DOUBLE_EDGE);
+        gpio_pin_configure(charging_dev, BAT_CHA, GPIO_DIR_IN | GPIO_INT
+                | EDGE);
         gpio_init_callback(&charging_cb, battery_callback_charging,
-                BIT(BAT_CHA_PIN));
+                BIT(BAT_CHA));
+	button_dev = device_get_binding(BTN_PORT);
+	gpio_pin_configure(button_dev, BTN_IN, GPIO_DIR_IN | GPIO_INT |  PULL_UP
+			   | EDGE);
+	gpio_init_callback(&button_cb, button_callback, BIT(BTN_IN));
 
 	/* Enable GPIOs */
 	gpio_add_callback(charging_dev, &charging_cb);
-        gpio_pin_enable_callback(charging_dev, BAT_CHA_PIN);
+        gpio_pin_enable_callback(charging_dev, BAT_CHA);
+	gpio_add_callback(button_dev, &button_cb);
+        gpio_pin_enable_callback(button_dev, BTN_IN);
+	
+	/* Set button out pin to high to enable the button */
+	u32_t button_out = 1U;
+        gpio_pin_configure(button_dev, BTN_OUT, GPIO_DIR_OUT);
+        gpio_pin_write(button_dev, BTN_OUT, button_out);
 
 	/* Initialize timers */
+	k_timer_init(&backlight_off_timer, backlight_off_interrupt_handler, NULL);
         k_timer_init(&battery_percentage_timer,
 		     battery_percentage_interrupt_handler, NULL);
 	k_timer_init(&clock_tick_timer, clock_callback_tick, NULL);
@@ -62,6 +82,11 @@ void event_handler_init()
 
 
 /* ********** handler functions ********** */
+void backlight_off_interrupt_handler(struct k_timer *light_off)
+{
+	backlight_enable(false);
+}
+
 void battery_percentage_interrupt_handler(struct k_timer *bat)
 {
         battery_update_percentage();
@@ -72,7 +97,14 @@ void battery_callback_charging(struct device *gpiob, struct gpio_callback *cb, u
         u32_t res = 0U;
         gpio_pin_read(charging_dev, 12, &res);
         battery_update_charging_status(res != 1U);
-	backlight_enable(!res);
+	backlight_enable(true);
+	k_timer_start(&backlight_off_timer, BACKLIGHT_OFF_TIME, 0);
+}
+
+void button_callback(struct device *gpiob, struct gpio_callback *cb, u32_t pins)
+{
+	backlight_enable(true);
+	k_timer_start(&backlight_off_timer, BACKLIGHT_OFF_TIME, 0);
 }
 
 void clock_callback_tick(struct k_timer *tick)

--- a/hypnos/src/main.c
+++ b/hypnos/src/main.c
@@ -33,10 +33,11 @@ void main(void)
 	display_init();
 	backlight_init();
 	event_handler_init();
-	
+
 	display_disable_blanking();
 
 	while (true) {
+		k_sleep(1);
 		k_cpu_idle();
 		lv_task_handler();
 	}


### PR DESCRIPTION
Pressing the button lights up the display and starts a 5 sec backlight-off
timer.  The same thing now happens when battery charging starts.