### PR TITLE
clock: show time and date in a nicer fashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and is inspired by [PineTime Hermes](https://github.com/Dejvino/pinetime-hermes-
 - [x] Clock: accurately increment current time
 - [x] Build current time of host machine into the firmware image
 - [x] Battery: show state of charge (%) and whether it's charging
-- [x] Graphics: show time and battery status using LittlevGL
+- [x] Graphics: show time, date and battery status using LittlevGL
 - [ ] Set alarm
 - [ ] Set current time from BLE-connected device
 - [ ] Show notifications from BLE-connected device

--- a/hypnos/src/clock.c
+++ b/hypnos/src/clock.c
@@ -15,8 +15,10 @@
 
 /* ********** ********** VARIABLES AND STRUCTS ********** ********** */
 static time_t local_time;
-static char clock_label_str[16];
+static char clock_label_str[32];
+static char date_label_str[32];
 static lv_obj_t *clock_label;
+static lv_obj_t *date_label;
 
 static struct tm ti = {
 	.tm_sec = 0,
@@ -70,32 +72,47 @@ void clock_increment_local_time()
 
 void clock_print_time()
 {
-	char wday[15];
-	char mon[15];
+	char wday[4];
+	char mon[4];
 
 	if (sscanf(clock_get_local_time(), "%s %s", wday, mon) != 2) {
 		LOG_ERR("Failed to print time!");
 	}
-	LOG_INF("%s %d %s\n", log_strdup(wday), localtime(&local_time)->tm_mday,
+	LOG_INF("%s %d %s", log_strdup(wday), localtime(&local_time)->tm_mday,
 		log_strdup(mon));
-	LOG_INF("%d:%d:%d", localtime(&local_time)->tm_hour,
-	       localtime(&local_time)->tm_min,
-	       localtime(&local_time)->tm_sec);
-	sprintf(clock_label_str, "%d:%d:%d", localtime(&local_time)->tm_hour,
-		localtime(&local_time)->tm_min,
-		localtime(&local_time)->tm_sec);
+	LOG_INF("%02d:%02d", localtime(&local_time)->tm_hour,
+		localtime(&local_time)->tm_min);
+	sprintf(clock_label_str, "%02d:%02d", localtime(&local_time)->tm_hour,
+		localtime(&local_time)->tm_min);
+	sprintf(date_label_str, "%s %d %s", wday,
+		localtime(&local_time)->tm_mday, mon);
 
+	/* Make the hours:minutes separator blink to represent seconds */
+	if (local_time % 2) {
+		clock_label_str[2] = ' ';
+	}
 	lv_label_set_text(clock_label, clock_label_str);
+	lv_label_set_text(date_label, date_label_str);
 }
 
 void clock_gfx_init()
 {
-	sprintf(clock_label_str, "%d:%d:%d", localtime(&local_time)->tm_hour,
-	       localtime(&local_time)->tm_min,
-	       localtime(&local_time)->tm_sec);
+	char wday[4];
+	char mon[4];
+
+	if (sscanf(clock_get_local_time(), "%s %s", wday, mon) != 2) {
+		LOG_ERR("Failed to print time!");
+	}
+	sprintf(clock_label_str, "%02d:%02d", localtime(&local_time)->tm_hour,
+		localtime(&local_time)->tm_min);
+	sprintf(date_label_str, "%s %d %s", wday,
+		localtime(&local_time)->tm_mday, mon);
 
 	clock_label = lv_label_create(lv_scr_act(), NULL);
+	date_label = lv_label_create(lv_scr_act(), NULL);
 	lv_label_set_text(clock_label, clock_label_str);
-	lv_obj_align(clock_label, NULL, LV_ALIGN_CENTER, 0, 0);
+	lv_label_set_text(date_label, date_label_str);
+	lv_obj_align(clock_label, NULL, LV_ALIGN_CENTER, 0, -10);
+	lv_obj_align(date_label, clock_label, LV_ALIGN_CENTER, 0, 26);
 }
 /* ********** ********** ********** ********** ********** */


### PR DESCRIPTION
- Add leading zeros to single digit numbers
- Remove the seconds component
- Add weekday, day of month and month
- Represent second ticks by toggling the HH:MM separator