### PR TITLE
west.yml: Update to snapshot of upstream master branch

### DIFF
--- a/boards/arm/pinetime/Kconfig.defconfig
+++ b/boards/arm/pinetime/Kconfig.defconfig
@@ -22,15 +22,6 @@ config SPI_0
 
 endif # SPI
 
-
-
-if PWM
-
-config PWM_0
-	default y
-
-endif # PWM
-
 config BT_CTLR
 	default BT
 

--- a/hypnos/prj.conf
+++ b/hypnos/prj.conf
@@ -3,7 +3,6 @@
 # Battery status
 CONFIG_ADC=y
 CONFIG_ADC_ASYNC=y
-CONFIG_ADC_0=y
 
 # GPIO
 CONFIG_GPIO=y

--- a/west.yml
+++ b/west.yml
@@ -21,24 +21,28 @@ manifest:
 
   remotes:
     - name: pinetime
-      url-base: https://github.com/zephyrproject-rtos/
+      url-base: https://github.com/zephyrproject-rtos
 
   # The list of external projects for the Pinetime.
   #
   projects:
+    - name: cmsis
+      path: modules/hal/cmsis
+      revision: 542b2296e6d515b265e25c6b7208e8fea3014f90
     - name: hal_nordic
       path: modules/hal/nordic
-      remote: pinetime
-      revision: 12d7647870888e4cb0e421f2b26884c2e76915ac
+      revision: e1168a2f3290f5ca17ec0c47efbf6c601c60108a
     - name: lvgl
-      revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
       path: modules/lib/gui/lvgl
+      revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
     - name: segger
-      revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger
+      revision: 6fcf61606d6012d2c44129edc033f59331e268bc
+    - name: tinycrypt
+      path: modules/crypto/tinycrypt
+      revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0
     - name: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 219d9fc08298cc99339fab9130c2cf299a3a3301
-
+      revision: 0b1ef3f6bcea2041170a412001698537361dcbbb
   self:
     path: pinetime


### PR DESCRIPTION
Sleep mode for the display has now been [accepted and merged upstream](https://github.com/zephyrproject-rtos/zephyr/pull/25138). After this merge, device power management can be integrated into the application.

As always there were API changes that had to be taking care of. I wasn't able to fix one thing though: building will result in lots of warnings about `DT_N_INST_0_nordic_nrf52832_qfaa DT_N`
being redefined to `DT_N_INST_0_nordic_nrf52832_qfaa DT_N_S_soc`. I can live with that for a while but will create a separate issue to remove the warnings.