### PR TITLE
power management: disable/enable display along with backlight

### DIFF
--- a/hypnos/include/display.h
+++ b/hypnos/include/display.h
@@ -8,6 +8,7 @@
 #define DISPLAY__H
 
 void display_init(void);
-void display_disable_blanking(void);
+void display_sleep(void);
+void display_wake_up(void);
 
 #endif /* DISPLAY__H */

--- a/hypnos/prj.conf
+++ b/hypnos/prj.conf
@@ -49,3 +49,6 @@ CONFIG_BT_GATT_CLIENT=y
 
 # Apparently necessary for bluetooth
 CONFIG_HEAP_MEM_POOL_SIZE=16384
+
+# Power management
+CONFIG_DEVICE_POWER_MANAGEMENT=y

--- a/hypnos/src/display.c
+++ b/hypnos/src/display.c
@@ -19,11 +19,31 @@ static struct device *display_dev;
 void display_init(void)
 {
 	display_dev = device_get_binding(CONFIG_LVGL_DISPLAY_DEV_NAME);
+	display_blanking_off(display_dev);
 	LOG_DBG("Display init: Done");
 }
 
-void display_disable_blanking(void)
+void display_sleep(void)
 {
-	display_blanking_off(display_dev);
+	(void)device_set_power_state(display_dev, DEVICE_PM_LOW_POWER_STATE, NULL,
+				     NULL);
+#ifdef CONFIG_LOG
+	int power_state = 0;
+	(void)device_get_power_state(display_dev, &power_state);
+	LOG_INF("Display power state: %u", power_state);
+#endif
 }
+
+void display_wake_up(void)
+{
+	(void)device_set_power_state(display_dev, DEVICE_PM_ACTIVE_STATE, NULL,
+				     NULL);
+#ifdef CONFIG_LOG
+	int power_state = 0;
+	(void)device_get_power_state(display_dev, &power_state);
+	LOG_INF("Display power state: %u", power_state);
+#endif
+}
+
+
 /* ********** ********** ********** ********** ********** */

--- a/hypnos/src/event_handler.c
+++ b/hypnos/src/event_handler.c
@@ -119,6 +119,7 @@ void event_handler_init()
 void backlight_off_isr(struct k_timer *light_off)
 {
 	backlight_enable(false);
+	display_sleep();
 }
 
 void battery_percentage_isr(struct k_timer *bat)
@@ -138,6 +139,7 @@ void button_pressed_isr(struct device *gpiobtn, struct gpio_callback *cb, u32_t 
 {
 	backlight_enable(true);
 	k_timer_start(&backlight_off_timer, BACKLIGHT_TIMEOUT, K_NO_WAIT);
+	display_wake_up();
 	bt_on();
 }
 
@@ -152,6 +154,7 @@ void touch_tap_isr(struct device *touch_dev, struct sensor_trigger *tap)
 {
 	backlight_enable(true);
 	k_timer_start(&backlight_off_timer, BACKLIGHT_TIMEOUT, K_NO_WAIT);
+	display_wake_up();
 }
 
 void bt_off_isr(struct k_timer *bt)

--- a/hypnos/src/main.c
+++ b/hypnos/src/main.c
@@ -29,7 +29,6 @@ void main(void)
 	event_handler_init();
 
 	lv_task_handler();
-	display_disable_blanking();
 	bt_on();
 	
 	while (true) {


### PR DESCRIPTION
When backlight gets disabled, put the display in sleep mode to save
lots of energy. Then wake up the display when backlight gets re-enabled.