### PR TITLE
Let the button toggle BT mode and improve the latter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ and is inspired by [PineTime Hermes](https://github.com/Dejvino/pinetime-hermes-
 ## Features
 
 - [x] 100 % Free Software
-- [x] Low power consumption: 1.38 mA in idle mode (1.28 mA with the heart rate sensor disconnected), which gives a battery life of more than five days.
+- [x] Low power consumption: 1.38 mA in idle mode (1.28 mA with the heart rate sensor disconnected), which gives a battery life of about one week.
 - [x] Battery status: get state of charge and whether it's charging
 - [x] Clock: accurately increment current time
-- [x] Button: press to start time synchronization with Bluetooth-connected device
+- [x] Button: press to toggle time synchronization with Bluetooth-connected device
 - [x] Touch sensor: tap to light up the display
 - [x] Graphics: show background image, time, date, battery and Bluetooth status using LittlevGL
 - [x] Optional debug output via JLink RTT
@@ -58,7 +58,7 @@ $ west flash
 
 ## Copying
 
-The Hypnos application is under the Mozilla Public License 2.0 and
+The Hypnos application is mostly under the Mozilla Public License 2.0 and
 the documentation, including this README, is CC BY-SA 4.0 or any later version.
 
 Everything else should be under Apache 2.0, MIT/Expat, 3-clause BSD or similar

--- a/hypnos/include/bt.h
+++ b/hypnos/include/bt.h
@@ -11,6 +11,8 @@ void bt_adv_start(void);
 void bt_adv_stop(void);
 void bt_on(void);
 void bt_off(void);
+void bt_toggle_unlock(void);
+bool bt_toggle_is_locked(void);
 void bt_await_on(void);
 void bt_await_off(void);
 

--- a/hypnos/include/cts_sync.h
+++ b/hypnos/include/cts_sync.h
@@ -12,7 +12,7 @@
 
 void cts_sync_init(void);
 void cts_sync_loop(void);
-void cts_get_datetime(struct tm *);
+void cts_update_datetime(struct tm *);
 
 typedef struct {
 	uint16_t year;

--- a/hypnos/include/event_handler.h
+++ b/hypnos/include/event_handler.h
@@ -12,7 +12,6 @@
 
 void event_handler_init(void);
 void display_off_isr(struct k_timer *);
-void bt_off_isr(struct k_timer *);
 void battery_percentage_isr(struct k_timer *);
 void battery_charging_isr(struct device*, struct gpio_callback *, u32_t);
 void button_pressed_isr(struct device *, struct gpio_callback *, u32_t);

--- a/hypnos/include/event_handler.h
+++ b/hypnos/include/event_handler.h
@@ -12,6 +12,7 @@
 
 void event_handler_init(void);
 void display_off_isr(struct k_timer *);
+void bt_toggle_unlock_isr(struct k_timer *);
 void battery_percentage_isr(struct k_timer *);
 void battery_charging_isr(struct device*, struct gpio_callback *, u32_t);
 void button_pressed_isr(struct device *, struct gpio_callback *, u32_t);

--- a/hypnos/src/bt.c
+++ b/hypnos/src/bt.c
@@ -29,6 +29,7 @@ K_SEM_DEFINE(disable_bt_sem, 0, 1);
 /* ********** variables ********** */
 bool bt_enabled = false;
 bool bt_initialized = false;
+bool bt_toggle_lock = false;
 
 struct k_sem enable_bt_sem;
 struct k_sem disable_bt_sem;
@@ -99,9 +100,19 @@ bool bt_is_initialized(void)
 	return bt_initialized;
 }
 
+bool bt_toggle_is_locked(void)
+{
+	if (bt_toggle_lock) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 void bt_on(void)
 {
 	bt_enabled = true;
+	bt_toggle_lock = true;
 	k_sem_give(&enable_bt_sem);
 }
 
@@ -110,9 +121,15 @@ void bt_await_on(void)
 	k_sem_take(&enable_bt_sem, K_FOREVER);
 }
 
+void bt_toggle_unlock(void)
+{
+	bt_toggle_lock = false;
+}
+
 void bt_off(void)
 {
 	bt_enabled = false;
+	bt_toggle_lock = true;
 	k_sem_give(&disable_bt_sem);
 }
 

--- a/hypnos/src/clock.c
+++ b/hypnos/src/clock.c
@@ -58,15 +58,16 @@ void clock_init()
 	LOG_DBG("Clock init: Done");
 }
 
-struct tm *clock_get_time()
-{
-	return &ti;
-}
-
+/* Called by cts sync */
 void clock_sync_time(void)
 {
-	cts_get_datetime(&ti);
+	cts_update_datetime(&ti);
 	local_time = mktime(&ti);
+
+	/* Flush the time incrementer */
+	uptime_ms = k_uptime_get();
+	elapsed_time_ms = uptime_ms - last_uptime_ms;
+	last_uptime_ms = uptime_ms;
 }
 
 char *clock_get_local_time()

--- a/hypnos/src/cts_sync.c
+++ b/hypnos/src/cts_sync.c
@@ -35,12 +35,13 @@ static void sync_cts_to_clock(cts_datetime_t* cts_datetime)
 	clock_datetime.minutes = cts_datetime->minutes;
 	clock_datetime.seconds = cts_datetime->seconds;
 
+	/* Update date and time in clock module */
+	clock_sync_time();
 	LOG_INF("CTS sync to clock complete.");
-
 	time_sync_timeout = TIME_SYNC_WAIT;
 }
 
-void cts_get_datetime(struct tm *t)
+void cts_update_datetime(struct tm *t)
 {
 	t->tm_year = clock_datetime.year -1900;
 	t->tm_mon = clock_datetime.month -1;
@@ -113,9 +114,9 @@ static void connected(struct bt_conn *conn, u8_t err)
 	cts_sync_processor(conn, NULL);
 }
 
-/* TODO: Remove, replace or fill it with something */
 static void disconnected(struct bt_conn *conn, u8_t reason)
 {
+	LOG_INF("Disconnected (reason %u)", reason);
 }
 
 static struct bt_conn_cb conn_callbacks = {

--- a/hypnos/src/event_handler.c
+++ b/hypnos/src/event_handler.c
@@ -26,11 +26,12 @@
 #define PULL_UP DT_GPIO_FLAGS(DT_ALIAS(sw0), gpios)
 #define TOUCH_PORT CONFIG_CST816S_NAME
 #define DISPLAY_TIMEOUT K_SECONDS(5)
-#define BT_TIMEOUT K_SECONDS(20)
+#define BT_TOGGLE_LOCK_TIMEOUT K_SECONDS(3)
 /* ********** ******* ********** */
 
 /* ********** variables ********** */
 static struct k_timer display_off_timer;
+static struct k_timer bt_toggle_timer;
 static struct device *charging_dev;
 static struct gpio_callback charging_cb;
 static struct device *button_dev;
@@ -67,6 +68,7 @@ void event_handler_init()
 
 	/* Initialize timers */
 	k_timer_init(&display_off_timer, display_off_isr, NULL);
+	k_timer_init(&bt_toggle_timer, bt_toggle_unlock_isr, NULL);
 
 	/* Start timers */
 	k_timer_start(&display_off_timer, DISPLAY_TIMEOUT, K_NO_WAIT);
@@ -92,6 +94,11 @@ void display_off_isr(struct k_timer *light_off)
 	display_sleep();
 }
 
+void bt_toggle_unlock_isr(struct k_timer *bt_toggle)
+{
+	bt_toggle_unlock();
+}
+
 void battery_charging_isr(struct device *gpiobat, struct gpio_callback *cb, u32_t pins)
 {
 	u32_t res = gpio_pin_get(charging_dev, BAT_CHA);
@@ -105,6 +112,11 @@ void button_pressed_isr(struct device *gpiobtn, struct gpio_callback *cb, u32_t 
 	display_wake_up();
 	clock_show_time();
 	battery_show_status();
+	if (bt_toggle_is_locked()) {
+		return;
+	}
+	k_timer_start(&bt_toggle_timer, BT_TOGGLE_LOCK_TIMEOUT, K_NO_WAIT);
+
 	if (bt_mode()) {
 		gfx_bt_set_label(0);
 		gfx_update();

--- a/hypnos/src/event_handler.c
+++ b/hypnos/src/event_handler.c
@@ -31,7 +31,6 @@
 
 /* ********** variables ********** */
 static struct k_timer display_off_timer;
-static struct k_timer bt_off_timer;
 static struct device *charging_dev;
 static struct gpio_callback charging_cb;
 static struct device *button_dev;
@@ -68,7 +67,6 @@ void event_handler_init()
 
 	/* Initialize timers */
 	k_timer_init(&display_off_timer, display_off_isr, NULL);
-	k_timer_init(&bt_off_timer, bt_off_isr, NULL);
 
 	/* Start timers */
 	k_timer_start(&display_off_timer, DISPLAY_TIMEOUT, K_NO_WAIT);
@@ -94,11 +92,6 @@ void display_off_isr(struct k_timer *light_off)
 	display_sleep();
 }
 
-void bt_off_isr(struct k_timer *bt)
-{
-	bt_off();
-}
-
 void battery_charging_isr(struct device *gpiobat, struct gpio_callback *cb, u32_t pins)
 {
 	u32_t res = gpio_pin_get(charging_dev, BAT_CHA);
@@ -110,12 +103,17 @@ void button_pressed_isr(struct device *gpiobtn, struct gpio_callback *cb, u32_t 
 	backlight_enable(true);
 	k_timer_start(&display_off_timer, DISPLAY_TIMEOUT, K_NO_WAIT);
 	display_wake_up();
-	gfx_bt_set_label(1);
 	clock_show_time();
 	battery_show_status();
-	gfx_update();
-	k_timer_start(&bt_off_timer, BT_TIMEOUT, K_NO_WAIT);
-	bt_on();
+	if (bt_mode()) {
+		gfx_bt_set_label(0);
+		gfx_update();
+		bt_off();
+	} else {
+		gfx_bt_set_label(1);
+		gfx_update();
+		bt_on();
+	}
 }
 
 void touch_tap_isr(struct device *touch_dev, struct sensor_trigger *tap)

--- a/hypnos/src/main.c
+++ b/hypnos/src/main.c
@@ -29,6 +29,8 @@ K_THREAD_DEFINE(bt_id, STACKSIZE, bt_thread, NULL, NULL, NULL,
                 PRIORITY, 0, 0);
 K_THREAD_DEFINE(main_id, STACKSIZE, main_thread, NULL, NULL, NULL,
                 PRIORITY, 0, 0);
+
+#define SLEEP_TIME K_MSEC(10)
 /* ******** thread function declarations and defines ******** */
 
 void main(void)
@@ -61,7 +63,7 @@ void main_thread(void)
 		bt_await_off();
 		bt_adv_stop();
 		while (true) {
-			k_sleep(K_MSEC(10));
+			k_sleep(SLEEP_TIME);
 			if (bt_mode()) {
 				gfx_bt_set_label(1);
 				gfx_update();
@@ -82,18 +84,18 @@ void bt_thread(void)
 			bt_adv_start();
 		} else {
 			bt_init();
-			k_sleep(K_MSEC(10));
+			k_sleep(SLEEP_TIME);
 		}
 		cts_sync_loop();
 		while (true) {
-			clock_sync_time();
+			k_sleep(SLEEP_TIME);
 			if (!bt_mode()) {
 				LOG_INF("Exiting bluetooth mode...");
 				gfx_bt_set_label(0);
 				gfx_update();
 				goto await_enable_bt;
 			}
-			k_sleep(K_MSEC(10));
+			k_cpu_idle();
 		}
 	}
 }


### PR DESCRIPTION
- Remove the timeout for BT mode
- Let cts_sync update date and time in clock module
- Flush time incrementer after time sync
- Do minor cleanups in cts_sync and clock
- Add k_cpu_idle() to BT mode

This should make Bluetooth mode more similar to the main mode. The only real difference is the radio being on or off. @Lukas-Berglund, what do you think?