### PR TITLE
Add optional bootloader support

### DIFF
--- a/app/boards/arm/p8/p8.dts
+++ b/app/boards/arm/p8/p8.dts
@@ -36,7 +36,7 @@
 		};
 		led2_blue: led_2 {
 			gpios = <&gpio0 23 GPIO_INT_ACTIVE_LOW>;
-			label = "Background LED 1";
+			label = "Background LED 2";
 		};
 	};
 
@@ -137,6 +137,16 @@
 		jedec-id = [0b 40 16];
 		size = <67108864>;
 		has-be32k;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@40000 {
+					 label = "image-1";
+					 reg = <0x00040000 0x74000>;
+			};
+		};
 	};
 };
 
@@ -152,23 +162,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 0x8000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x00008000 0x74000>;
 		};
-		slot1_partition: partition@3e000 {
-			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
+		scratch_partition: partition@7C000 {
 			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
-		};
-		storage_partition: partition@7a000 {
-			label = "storage";
-			reg = <0x0007a000 0x00006000>;
+			reg = <0x0007C000 0xA000>;
 		};
 	};
 };

--- a/app/boards/arm/pinetime/pinetime.dts
+++ b/app/boards/arm/pinetime/pinetime.dts
@@ -36,7 +36,7 @@
 		};
 		led2_blue: led_2 {
 			gpios = <&gpio0 23 GPIO_INT_ACTIVE_LOW>;
-			label = "Background LED 1";
+			label = "Background LED 2";
 		};
 	};
 
@@ -137,6 +137,16 @@
 		jedec-id = [0b 40 16];
 		size = <67108864>;
 		has-be32k;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			slot1_partition: partition@40000 {
+					 label = "image-1";
+					 reg = <0x00040000 0x74000>;
+			};
+		};
 	};
 };
 
@@ -152,23 +162,15 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 0x8000>;
 		};
-		slot0_partition: partition@c000 {
+		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0000C000 0x32000>;
+			reg = <0x00008000 0x74000>;
 		};
-		slot1_partition: partition@3e000 {
-			label = "image-1";
-			reg = <0x0003E000 0x32000>;
-		};
-		scratch_partition: partition@70000 {
+		scratch_partition: partition@7C000 {
 			label = "image-scratch";
-			reg = <0x00070000 0xa000>;
-		};
-		storage_partition: partition@7a000 {
-			label = "storage";
-			reg = <0x0007a000 0x00006000>;
+			reg = <0x0007C000 0xA000>;
 		};
 	};
 };

--- a/app/hypnos/CMakeLists.txt
+++ b/app/hypnos/CMakeLists.txt
@@ -2,17 +2,17 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-# Add the pinetime board
+# Add the board
 list(APPEND BOARD_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
 list(APPEND DTS_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
 
 # Config files
-IF("$ENV{LOGGING}" STREQUAL "off")
-  message(STATUS "LOGGING will be disabled.")
-  set(CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/prj.conf)
-ELSE()
-  message(STATUS "LOGGING will be enabled.")
-  set(CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/prj.conf ${CMAKE_CURRENT_LIST_DIR}/logging.conf)
+set(CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/prj.conf)
+IF("$ENV{BOOTLOADER}" STREQUAL "on")
+  set(CONF_FILE ${CONF_FILE} ${CMAKE_CURRENT_LIST_DIR}/bootloader.conf)
+ENDIF()
+IF("$ENV{LOGGING}" STREQUAL "on")
+  set(CONF_FILE ${CONF_FILE} ${CMAKE_CURRENT_LIST_DIR}/logging.conf)
 ENDIF()
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})

--- a/app/hypnos/bootloader.conf
+++ b/app/hypnos/bootloader.conf
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Bootloader and DFU
+CONFIG_BOOTLOADER_MCUBOOT=y
+CONFIG_IMG_MANAGER=y
+
+# Flash operations
+CONFIG_FLASH=y
+
+# Disable memory protection
+CONFIG_ARM_MPU=n

--- a/app/hypnos/src/backlight.c
+++ b/app/hypnos/src/backlight.c
@@ -11,7 +11,9 @@
 
 /* ********** ********** DEFINES ********** ********** ********** */
 #define BACKLIGHT_PORT  DT_GPIO_LABEL(DT_ALIAS(led1), gpios)
-#define BACKLIGHT       DT_GPIO_PIN(DT_ALIAS(led1), gpios)
+#define BACKLIGHT_1     DT_GPIO_PIN(DT_ALIAS(led0), gpios)
+#define BACKLIGHT_2     DT_GPIO_PIN(DT_ALIAS(led1), gpios)
+#define BACKLIGHT_3     DT_GPIO_PIN(DT_ALIAS(led2), gpios)
 /* ********** **********  ********** ********** ********** */
 
 /* ********** ********** VARIABLES AND STRUCTS ********** ********** */
@@ -23,14 +25,18 @@ static bool backlight_enabled = false;
 void backlight_init()
 {
 	backlight_dev = device_get_binding(BACKLIGHT_PORT);
-	gpio_pin_configure(backlight_dev, BACKLIGHT, GPIO_OUTPUT);
+	gpio_pin_configure(backlight_dev, BACKLIGHT_1, GPIO_OUTPUT);
+	gpio_pin_configure(backlight_dev, BACKLIGHT_2, GPIO_OUTPUT);
+	gpio_pin_configure(backlight_dev, BACKLIGHT_3, GPIO_OUTPUT);
 	backlight_enable(true);
 	LOG_DBG("Backlight init: Done");
 }
 
 void backlight_enable(bool enable)
 {
-	gpio_pin_set_raw(backlight_dev, BACKLIGHT, enable ? 0 : 1);
+	gpio_pin_set_raw(backlight_dev, BACKLIGHT_1, enable ? 0 : 1);
+	gpio_pin_set_raw(backlight_dev, BACKLIGHT_2, enable ? 0 : 1);
+	gpio_pin_set_raw(backlight_dev, BACKLIGHT_3, enable ? 0 : 1);
 	backlight_enabled = enable;
 }
 

--- a/app/hypnos/src/main.c
+++ b/app/hypnos/src/main.c
@@ -17,6 +17,9 @@
 #include "event_handler.h"
 #include "gfx.h"
 #include "log.h"
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+	#include "dfu/mcuboot.h"
+#endif
 
 /* ******** Thread prototypes, constants and macros ******** */
 void main_thread(void);
@@ -43,6 +46,14 @@ void main(void)
 	event_handler_init();
 	gfx_update();
 	backlight_init();
+
+#ifdef CONFIG_BOOTLOADER_MCUBOOT
+	/* TODO: Ask the user to confirm the new image */
+	if (!boot_is_img_confirmed()) {
+		LOG_DBG("Confirming new firmware image.");
+		(void)boot_write_img_confirmed();
+	}
+#endif
 }
 
 void main_thread(void)

--- a/app/west.yml
+++ b/app/west.yml
@@ -35,6 +35,9 @@ manifest:
     - name: lvgl
       path: modules/lib/gui/lvgl
       revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
+    - name: mcuboot
+      revision: e88113bbebe34ff2ccc6627ffae885cfeed6fdfd
+      path: bootloader/mcuboot
     - name: segger
       path: modules/debug/segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc


### PR DESCRIPTION
- west.yml: add mcuboot
- pinetime and p8 dts: new partition layout for internal flash and external SPI flash memory
- add dfu.conf
- cmake: build with dfu.conf if environment variable DFU="on"
- cmake: build with logging.conf only if environment variable LOGGING="on"
- main: confirm new image automatically
- backlight: use all three LEDs instead of just one
- README: update documentation

If DFU is not set to "on", then all the code changes here should be ignored except:
- the backlight fix (thanks @jf002!)
- logging, which will now be disabled by default