### PR TITLE
boards: p8: change jedec-id for SPI flash

### DIFF
--- a/app/boards/arm/p8/p8.dts
+++ b/app/boards/arm/p8/p8.dts
@@ -134,7 +134,7 @@
 		reg = <1>;
 		spi-max-frequency = <1000000>;
 		label = "MX25R64";
-		jedec-id = [0b 40 16];
+		jedec-id = [20 40 16];
 		size = <67108864>;
 		has-be32k;
 	};


### PR DESCRIPTION
This should fix #87 but it has not yet been confirmed.