### PR TITLE
Add Makefile and other changes to the build system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
         id: vars
         shell: bash
         run:
-          echo "::set-output name=fw_ver::$(git describe --tags)"
+          echo "::set-output name=fw_ver::$(git describe --tags --dirty)"
       # Upload zephyr firmware build
       - name: Upload firmware build
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /zephyr
 /app/build
 /build
+/images
+GPATH
+GRTAGS
+GTAGS

--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,20 @@ help:
 	@echo "images and DFU packages for devices running Lup Yuen Lee's"
 	@echo "custom MCUBoot bootloader\n"
 	@echo "Usage:"
-	@echo "  make [TARGET] [BOARD=p8]\n"
+	@echo "  make [OPTION]... [TARGET]\n"
+	@echo "Options:"
+	@echo "  BOARD=p8     build for p8 instead of pinetime"
+	@echo "  BOOTLOADER=n disable bootloader support"
+	@echo "  LOGGING=y    enable RTT logging"
 	@echo "Targets:"
-	@echo "  build    build application firmware"
-	@echo "  clean    remove the build directory"
-	@echo "  dfu      build a Device Firmare Upgrade package"
-	@echo "  flash    flash the most recent image over the SWD interface"
-	@echo "  help     show this message and exit"
-	@echo "  image    build an MCUBoot app image"
-	@echo "  print    print various strings for debugging this Makefile"
-	@echo "  tools    install tools for creating images and DFU packages"
+	@echo "  build        build application firmware"
+	@echo "  clean        remove the build directory"
+	@echo "  dfu          build a Device Firmare Upgrade package"
+	@echo "  flash        flash the most recent app image or firmware build over SWD"
+	@echo "  help         show this message and exit"
+	@echo "  image        build an MCUBoot app image"
+	@echo "  print        print variables and file paths for debugging this Makefile"
+	@echo "  tools        install tools for creating images and DFU packages"
 
 tools:
 	@echo "Installing tools for creating app images and DFU packages"
@@ -63,7 +67,7 @@ $(IMGDIR):
 	mkdir $(IMGDIR)
 
 $(BUILD):
-	west build -p -b $(BOARD) app/hypnos
+	west build -p auto -b $(BOARD) app/hypnos
 
 $(PACKAGE): $(IMAGE)
 	@echo "Creating a Device Firmware Update package"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BOOTLOADER := $(shell cat build/zephyr/.config 2>/dev/null \
 endif
 
 BUILD   := build/zephyr/zephyr.bin
-VERSION := $(shell git describe --tags)
+VERSION := $(shell git describe --tags --dirty)
 IMGDIR  := images
 IMAGE   := $(IMGDIR)/$(BOARD)-hypnos-$(VERSION)-mcuboot-app-img.bin
 PACKAGE := $(IMGDIR)/$(BOARD)-hypnos-$(VERSION)-mcuboot-app-dfu.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+# Copyright (c) 2020 Endian Technologies AB
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ifneq ($(BOARD),p8)
+BOARD   := $(shell cat build/zephyr/.config 2>/dev/null | grep CONFIG_BOARD= \
+                       | cut -d'"' -f 2 2>/dev/null)
+ifndef BOARD
+BOARD := pinetime
+endif
+endif
+
+ifneq ($(BOOTLOADER),n)
+BOOTLOADER := $(shell cat build/zephyr/.config 2>/dev/null \
+                      | grep BOOTLOADER_MCUBOOT \
+                      | cut -d'=' -f 2 | tr -cd '[ny]\n')
+endif
+
+BUILD   := build/zephyr/zephyr.bin
+VERSION := $(shell git describe --tags)
+IMGDIR  := images
+IMAGE   := $(IMGDIR)/$(BOARD)-hypnos-$(VERSION)-mcuboot-app-img.bin
+PACKAGE := $(IMGDIR)/$(BOARD)-hypnos-$(VERSION)-mcuboot-app-dfu.zip
+
+.PHONY: build clean help tools
+
+ifneq  ($(BOOTLOADER),n)
+dfu: $(BUILD) $(IMAGE) $(PACKAGE)
+image: $(BUILD) $(IMAGE)
+
+$(IMAGE): $(BUILD) | $(IMGDIR)
+	@echo "Creating an MCUBoot app image"
+	bootloader/mcuboot/scripts/imgtool.py create --align 4 --version 1.0.0 \
+	--header-size 512 --slot-size 475136 $(BUILD) $(IMAGE)
+endif
+build:
+	west build -p -b $(BOARD) app/hypnos
+
+help:
+	@echo "Build and flash the Hypnos application firmware as well as"
+	@echo "images and DFU packages for devices running Lup Yuen Lee's"
+	@echo "custom MCUBoot bootloader\n"
+	@echo "Usage:"
+	@echo "  make [TARGET] [BOARD=p8]\n"
+	@echo "Targets:"
+	@echo "  build    build application firmware"
+	@echo "  clean    remove the build directory"
+	@echo "  dfu      build a Device Firmare Upgrade package"
+	@echo "  flash    flash the most recent image over the SWD interface"
+	@echo "  help     show this message and exit"
+	@echo "  image    build an MCUBoot app image"
+	@echo "  print    print various strings for debugging this Makefile"
+	@echo "  tools    install tools for creating images and DFU packages"
+
+tools:
+	@echo "Installing tools for creating app images and DFU packages"
+	pip3 install --user setuptools
+	pip3 install --user -r bootloader/mcuboot/scripts/requirements.txt
+	pip3 install --user pyocd
+	@echo "Done"
+
+$(IMGDIR):
+	mkdir $(IMGDIR)
+
+$(BUILD):
+	west build -p -b $(BOARD) app/hypnos
+
+$(PACKAGE): $(IMAGE)
+	@echo "Creating a Device Firmware Update package"
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application $(IMAGE) \
+	$(PACKAGE)
+
+ifneq ($(BOOTLOADER),n)
+flash: $(BUILD) $(IMAGE)
+	@echo "Flashing the last modified Hypnos image after the bootloader"
+	pyocd flash -e sector -a 0x8000 -t nrf52 $(shell ls -t images/*.bin | head -1)
+else
+flash: $(BUILD)
+	@echo "Flashing Hypnos firmware without bootloader support"
+	west flash
+endif
+
+clean:
+	rm -rf build/
+
+print:
+	@echo "Board:      $(BOARD)"
+	@echo "Bootloader: $(BOOTLOADER)"
+	@echo "Version:    $(VERSION)"
+	@echo "Build:      $(BUILD)"
+	@echo "Image:      $(IMAGE)"
+	@echo "Package:    $(PACKAGE)"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a [Zephyr](https://www.zephyrproject.org/)-based firmware for the
 - [ ] Wrist vibration
 - [ ] Quick glance via lift-to-wake
 
-## Getting started
+## Developer getting started guide
 
 This document assumes that you run a GNU/Linux or Mac operating system.
 
@@ -44,31 +44,20 @@ $ west init -l app/
 $ west update
 ```
 
-Then complete the remaining steps under section 3 and 4.
+Then complete the remaining steps under section 3 and 4. Finally, run `make
+tools`.
 
-Finally, run `make tools`.
+### Build and flash Hypnos
 
-### Configure
+Run `make` to build everything with the defaults or `make help` to view all the
+options and targets.
 
-Optionally override the default configuration:
-```
-$ export BOARD=p8     # build for p8 instead of pinetime
-$ export BOOTLOADER=n # disable bootloader support
-$ export LOGGING=y    # enable RTT logging
-```
+Then connect your in-circuit programmer and run `make flash`. To install
+without a programmer, see Firmware updates below.
 
-### Build
+### Build and flash the bootloader
 
-Run `make build` to compile the application firmware or `make image` to generate
-an MCUboot app image.
-
-### Install
-
-Connect your in-circuit programmer and run `make flash`.
-
-### Build and install the bootloader
-
-To install the compatible PineTime bootloader, follow Lup Yuen's [build
+To install or upgrade the bootloader, follow Lup Yuen's [build
 instructions](https://lupyuen.github.io/pinetime-rust-mynewt/articles/mcuboot#build-and-flash-mcuboot-bootloader)
 or [fetch the prebuilt
 binary](https://github.com/lupyuen/pinetime-rust-mynewt/releases/tag/v5.0.4).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hypnos
 
 This is a [Zephyr](https://www.zephyrproject.org/)-based firmware for the
-[PineTime](https://www.pine64.org/pinetime/) smartwatch.
+[PineTime](https://www.pine64.org/pinetime/) and P8 smartwatches.
 
 <img src="app/hypnos/watch_photo.jpg" title="Hypnos watch (CC BY-SA 4.0)">
 
@@ -28,11 +28,15 @@ This is a [Zephyr](https://www.zephyrproject.org/)-based firmware for the
 
 ## Getting started
 
+This document assumes that you run a GNU/Linux or Mac operating system.
+
 ### Set up the development environment
 
-Follow Zephyr's [Getting Started Guide](https://docs.zephyrproject.org/latest/getting_started/index.html)
-up to step 3.2 "Get the Zephyr source code". Here you should run the commands below
+Follow Zephyr's [Getting Started
+Guide](https://docs.zephyrproject.org/latest/getting_started/index.html) up to
+step 3.2 "Get the Zephyr source code". Here you should run the commands below
 instead of the ones in the guide:
+
 ```
 $ git clone https://github.com/endian-albin/pinetime-hypnos
 $ cd pinetime-hypnos
@@ -42,65 +46,48 @@ $ west update
 
 Then complete the remaining steps under section 3 and 4.
 
+Finally, run `make tools`.
+
 ### Configure
 
-Optionally enable RTT logging and/or disable bootloader support:
+Optionally override the default configuration:
 ```
-$ export BOOTLOADER="off"
-$ export LOGGING="on"
+$ export BOARD=p8     # build for p8 instead of pinetime
+$ export BOOTLOADER=n # disable bootloader support
+$ export LOGGING=y    # enable RTT logging
 ```
 
 ### Build
 
-Build the firmware for either `pinetime` or `p8` (replace `<board>` below):
-```
-$ cd app/
-$ west build -p -b <board> hypnos
-```
+Run `make build` to compile the application firmware or `make image` to generate
+an MCUboot app image.
 
 ### Install
 
-Generate an mcuboot app image:
-```
-$ cd ../bootloader/mcuboot/scripts
-$ pip3 install --user setuptools
-$ pip3 install --user -r requirements.txt
-$ ./imgtool.py create --align 4 --version 1.0.0 --header-size 512 --slot-size 475136 ../../../app/build/zephyr/zephyr.bin hypnos-mcuboot-app.bin
-```
-Connect your in-circuit programmer to the SWD pins on the watch.
-
-Flash the image to offset 0x8000:
-```
-pyocd flash -e sector -a 0x8000 -t nrf52 hypnos-dfu-app.bin
-```
-
-If you have disabled bootloader support, flash the application directly using pyocd:
-```
-$ west flash
-```
-...or run `west flash --context` for more options.
-
+Connect your in-circuit programmer and run `make flash`.
 
 ### Build and install the bootloader
 
-To install the compatible PineTime bootloader, follow Lup Yuen's
-[build instructions](https://lupyuen.github.io/pinetime-rust-mynewt/articles/mcuboot#build-and-flash-mcuboot-bootloader)
-or [fetch the prebuilt binary](https://github.com/lupyuen/pinetime-rust-mynewt/releases/tag/v5.0.0).
+To install the compatible PineTime bootloader, follow Lup Yuen's [build
+instructions](https://lupyuen.github.io/pinetime-rust-mynewt/articles/mcuboot#build-and-flash-mcuboot-bootloader)
+or [fetch the prebuilt
+binary](https://github.com/lupyuen/pinetime-rust-mynewt/releases/tag/v5.0.4).
 
 Then flash it to the beginning of the internal memory:
-
 ```
 pyocd flash -e sector -t nrf52 bootloader-image.bin
 ```
 
-## Firmware upgrades and downgrades
+## Firmware updates
 
 ### SMP over Bluetooth LE
 
 Hypnos supports firmware image management over the Simple Management Protocol.
 
-To make use of this feature, get the [mcumgr](https://github.com/apache/mynewt-mcumgr#command-line-tool) command-line tool.
-Then run the commands below to list, upload, test and confirm firmware images over BLE:
+To make use of this feature, get the
+[mcumgr](https://github.com/apache/mynewt-mcumgr#command-line-tool) command-line
+tool. Then run the commands below to list, upload, test and confirm firmware
+images over BLE:
 
 ```
 # mcumgr --conntype="ble" --connstring ctlr_name=hci0,peer_name='Hypnos' image list
@@ -113,27 +100,17 @@ Then run the commands below to list, upload, test and confirm firmware images ov
 If you are unhappy with the new image, simply run the `reset` command again
 instead of `image confirm` to revert to the old one. If the image has already
 been confirmed but you still want to revert, simply run the commands above but
-skip the upload step or perform a manual rollback (see below).
-[See this document for more information](https://docs.zephyrproject.org/latest/samples/subsys/mgmt/mcumgr/smp_svr/README.html).
+skip the upload step or perform a manual rollback (see below). [See this
+document for more
+information](https://docs.zephyrproject.org/latest/samples/subsys/mgmt/mcumgr/smp_svr/README.html).
 
-### DFU legacy mode over Bluetooth LE
+### DFU over Bluetooth LE
 
-To install Hypnos over the air from [InfiniTime](https://github.com/JF002/Pinetime)
-you need to create a SoftDevice DFU zip package and upload that.
-
-Install adafruit-nrfutil:
-```
-$ pip3 install --user wheel
-$ pip3 install --user setuptools
-$ pip3 install --user adafruit-nrfutil
-```
-
-Create the zip package from the imgtool.py output above:
-```
-$ adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application hypnos-mcuboot-app-img.bin hypnos-mcuboot-app-dfu.zip
-```
-
-Connect to InfiniTime and upload `hypnos-mcuboot-app-dfu.zip`.
+To install Hypnos over the air from
+[InfiniTime](https://github.com/JF002/Pinetime), run `make dfu` to create a
+(Nordic) DFU package and upload it using
+[ota-dfu.py](https://github.com/JF002/Pinetime/tree/master/bootloader/ota-dfu-python)
+or nRF Connect.
 
 ### Manual rollback
 
@@ -142,8 +119,8 @@ image by holding the button during boot.
 
 ## Copying
 
-This software may be used under the terms of the Apache License 2.0,
-unless explicitly stated otherwise.
+This software may be used under the terms of the Apache License 2.0, unless
+explicitly stated otherwise.
 
-The documentation contained in this README and on the wiki are under
-the CC BY-SA 4.0 license.
+The documentation contained in this README and on the wiki are under the CC
+BY-SA 4.0 license.

--- a/app/hypnos/CMakeLists.txt
+++ b/app/hypnos/CMakeLists.txt
@@ -8,10 +8,10 @@ list(APPEND DTS_ROOT ${CMAKE_CURRENT_LIST_DIR}/..)
 
 # Enable configurations through environment variables
 set(CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/config/prj.conf ${CMAKE_CURRENT_LIST_DIR}/config/bootloader.conf)
-IF("$ENV{BOOTLOADER}" STREQUAL "off")
+IF("$ENV{BOOTLOADER}" STREQUAL n)
   set(CONF_FILE ${CMAKE_CURRENT_LIST_DIR}/config/prj.conf)
 ENDIF()
-IF("$ENV{LOGGING}" STREQUAL "on")
+IF("$ENV{LOGGING}" STREQUAL y)
   set(CONF_FILE ${CONF_FILE} ${CMAKE_CURRENT_LIST_DIR}/config/logging_rtt.conf)
 ENDIF()
 

--- a/app/hypnos/CMakeLists.txt
+++ b/app/hypnos/CMakeLists.txt
@@ -27,7 +27,7 @@ string(TIMESTAMP CURRENT_TIME %Y-%m-%dT%H:%M:%S)
 
 # Get short commit hash
 execute_process(
-  COMMAND ${GIT_EXECUTABLE} describe --tags
+  COMMAND ${GIT_EXECUTABLE} describe --tags --dirty
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   OUTPUT_VARIABLE FW_BUILD_GIT
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
This adds a Makefile as the recommended method for building firmware, generating images and packages as well as flashing. Just `make` will build all of them and `make help` will explain the commands. If the firmware was built without bootloader support, then make flash will simply run `west flash` and thus flash `zephyr.hex`, otherwise it will use pyocd to flash the last modified MCUboot app image to offset 0x8000.

This PR also changes configuration values `"on"` and `"off"` to `y` and `n` respectively, which are nicer I think and plays well with Kconfigs in a way and adds `--dirty` to `git describe` to mark builds depending on uncommitted modifications.